### PR TITLE
Add libgcrypt-devel for it is required for VNC connections

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1045,7 +1045,7 @@ s_echo "y" "${Bold}Installing Required Dependencies"
 
 # Install Required Packages
 {
-	yum install -y cairo-devel ffmpeg-devel freerdp-devel freerdp-plugins gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel libwebsockets-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
+	yum install -y cairo-devel ffmpeg-devel freerdp-devel freerdp-plugins gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel libwebsockets-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel libgcrypt-devel
 } &
 s_echo "n" "${Reset}-Installing required packages...    "; spinner
 


### PR DESCRIPTION
Trying VNC I got the error message:

> guacamole support for protocol vnc is not installed

The VNC module is not build without libgcrypt-devel

---

For later support in a running build you can use the following. A guacamole restart it not required.

```bash
cd /usr/local/src/guacamole/1.4.0/server/src/protocols/vnc
yum install libgcrypt-devel
make
make install
```
